### PR TITLE
Provide results from a specification via a hook function.

### DIFF
--- a/src/components/mapProps.ts
+++ b/src/components/mapProps.ts
@@ -1,5 +1,10 @@
-import { Specification, Mapping } from './mapping';
+import { Specification, Mapping } from '../specifications/mapping';
 
+/**
+ * Map a specification to the properties of a component.
+ * 
+ * @param specification A specification created by specificationFor, which defines the properties
+ */
 export function mapProps<M, VM>(
   specification: Specification<M, VM>
 ): { to: <P>(PresentationComponent: React.ComponentType<VM & P>) => Mapping<M, VM, P> } {

--- a/src/components/mapProps.ts
+++ b/src/components/mapProps.ts
@@ -2,8 +2,13 @@ import { Specification, Mapping } from '../specifications/mapping';
 
 /**
  * Map a specification to the properties of a component.
+ * The specification determines what props are passed to the component in order to render the fact.
+ * If the component takes additional props, they will remain unbound.
+ * In TypeScript, pass the unbound props type to the generic function *to*.
  * 
- * @param specification A specification created by specificationFor, which defines the properties
+ * Unbound props are set in the resulting container component when either {@link container} or {@link jinagaContainer} is used.
+ * 
+ * @param specification A specification created by {@link specificationFor}, which defines the properties.
  */
 export function mapProps<M, VM>(
   specification: Specification<M, VM>

--- a/src/hooks/useResult.ts
+++ b/src/hooks/useResult.ts
@@ -5,6 +5,18 @@ import { Transformer, WatchContext } from '../specifications/declaration';
 import { Specification } from '../specifications/mapping';
 import { createStore, Store, StorePath } from '../store/store';
 
+/**
+ * Load the result of a specification within a function component.
+ * This is kept as component state by means of the useState hook.
+ * 
+ * The result will be null until the result is fully loaded.
+ * Be sure to check for null and render a loading state.
+ * Thereafter, the result will update as new facts are added.
+ * 
+ * @param j The Jinaga object.
+ * @param fact The starting point for all queries in the specification.
+ * @param specification Specifies the fields that will be generated from Jinaga queries. Create the specification with {@link specificationFor}.
+ */
 export function useResult<M, VM>(j: Jinaga, fact: M | null, specification: Specification<M, VM>): VM | null {
   const [ store, setStore ] = React.useState<Store | null>(null);
   const [ loaded, setLoaded ] = React.useState<boolean>(false);

--- a/src/hooks/useResult.ts
+++ b/src/hooks/useResult.ts
@@ -1,0 +1,66 @@
+import { Jinaga, Preposition, Watch } from 'jinaga';
+import * as React from 'react';
+
+import { Transformer, WatchContext } from '../specifications/declaration';
+import { Specification } from '../specifications/mapping';
+import { createStore, Store, StorePath } from '../store/store';
+
+export function useResult<M, VM>(j: Jinaga, fact: M | null, specification: Specification<M, VM>): VM | null {
+  const [ store, setStore ] = React.useState<Store | null>(null);
+  const [ loaded, setLoaded ] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    setLoaded(false);
+    if (fact === null) {
+      setStore(null);
+      return () => {};
+    }
+
+    setStore(initializeStore(fact, specification));
+    const watches = startWatches(j, fact, specification, setStore);
+    Promise.all(watches.map(w => w.load())).then(() => {
+      setLoaded(true);
+    });
+    return () => {
+      stopWatches(watches);
+    };
+  }, [fact]);
+
+  const vm = (store && loaded) ? specification.getMappingValue(store) : null;
+  return vm;
+}
+
+function initializeStore<M, VM>(fact: M, specification: Specification<M, VM>): Store {
+  return createStore(
+    specification.initialMappingState(fact, []),
+    specification.initialMappingItems(fact, [])
+  );
+}
+
+function startWatches<M, VM>(
+  j: Jinaga,
+  fact: M,
+  specification: Specification<M, VM>,
+  setStore: React.Dispatch<React.SetStateAction<Store | null>>
+): Watch<M, WatchContext>[] {
+  if (!fact) {
+    return [];
+  }
+
+  const mutator = (transformer: Transformer<Store>) => {
+    setStore(s => s === null ? null : transformer(s));
+  };
+
+  function beginWatch<U>(
+      preposition: Preposition<M, U>,
+      resultAdded: (path: StorePath, child: U) => WatchContext
+  ) {
+      return j.watch(fact, preposition, c => resultAdded([], c), f => f.resultRemoved());
+  }
+
+  return specification.createMappingWatches(beginWatch, mutator);
+}
+
+function stopWatches<M>(watches: Watch<M, WatchContext>[]) {
+  watches.forEach(watch => watch.stop());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { ascending, collection, descending } from "./specifications/collection";
 export { BeginWatch, FieldDeclaration, Mutator, ViewModel, ViewModelDeclaration, WatchContext } from "./specifications/declaration";
 export { field } from "./specifications/field";
 export { jinagaContainer } from "./specifications/jinagaContainer";
-export { Mapping } from "./specifications/mapping";
+export { Mapping, Specification, ResultOf } from "./specifications/mapping";
 export { mutable, Mutable, prior } from "./specifications/mutable";
 export { projection } from "./specifications/projection";
 export { property } from "./specifications/property";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export { projection } from "./specifications/projection";
 export { property } from "./specifications/property";
 export { specificationFor } from "./specifications/specificationFor";
 export { addStoreItem, combineStorePath, removeStoreItem, Store, StorePath } from "./store/store";
-export { mapProps } from "./specifications/mapProps";
+export { mapProps } from "./components/mapProps";
+export { useResult } from "./hooks/useResult";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { projection } from "./specifications/projection";
 export { property } from "./specifications/property";
 export { specificationFor } from "./specifications/specificationFor";
 export { addStoreItem, combineStorePath, removeStoreItem, Store, StorePath } from "./store/store";
+export { mapProps } from "./specifications/mapProps";

--- a/src/specifications/mapProps.ts
+++ b/src/specifications/mapProps.ts
@@ -1,0 +1,15 @@
+import { Specification, Mapping } from './mapping';
+
+export function mapProps<M, VM>(
+  specification: Specification<M, VM>
+): { to: <P>(PresentationComponent: React.ComponentType<VM & P>) => Mapping<M, VM, P> } {
+  return (
+    {
+      to: PresentationComponent => (
+        {
+          ...specification,
+          PresentationComponent
+        })
+    }
+  );
+}

--- a/src/specifications/mapping.ts
+++ b/src/specifications/mapping.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Store, StorePath, StoreItem } from "../store/store";
 import { BeginWatch, Mutator, WatchContext } from "./declaration";
 
-export type Mapping<M, VM, P> = {
+type SpecificationBase<M, VM> = {
     initialMappingState(m: M, path: StorePath): VM;
     initialMappingItems(m: M, path: StorePath): { [collectionName: string]: StoreItem[] };
     getMappingValue(store: Store): VM;
@@ -11,5 +11,16 @@ export type Mapping<M, VM, P> = {
         beginWatch: BeginWatch<M>,
         mutator: Mutator<Store>
     ): Watch<M, WatchContext>[];
+};
+
+export type Specification<M, VM> = SpecificationBase<M, VM> & {
+    /**
+     * @deprecated Use the mapProps method instead.
+     */
+    <P>(PresentationComponent: React.ComponentType<VM & P>):
+        Mapping<M, VM, P>;
+};
+
+export type Mapping<M, VM, P> = SpecificationBase<M, VM> & {
     PresentationComponent: React.ComponentType<VM & P>
-}
+};

--- a/src/specifications/mapping.ts
+++ b/src/specifications/mapping.ts
@@ -24,3 +24,5 @@ export type Specification<M, VM> = SpecificationBase<M, VM> & {
 export type Mapping<M, VM, P> = SpecificationBase<M, VM> & {
     PresentationComponent: React.ComponentType<VM & P>
 };
+
+export type ResultOf<S> = S extends SpecificationBase<any, infer VM> ? VM : never;

--- a/src/specifications/specificationFor.ts
+++ b/src/specifications/specificationFor.ts
@@ -9,11 +9,13 @@ interface Type<T> extends Function {
 /**
  * Start here.
  * Create a specification for a certain type of fact.
- * The specification determines what props are passed to a component in order to render the fact.
+ * The specification declares a set of fields based on Jinaga queries.
  * 
- * Declare the props as a JavaScript object.
- * Each field of this declaration object has the same name as the resulting prop.
- * The value of the field determines how the 
+ * Declare the fields as a JavaScript object.
+ * Each field of this declaration object has the same name as the resulting field.
+ * 
+ * To pass these fields as props into a component, use {@link mapProps}.
+ * To get these fields as state in a function component, use {@link useResult}.
  * 
  * @param modelConstructor Constructor for the root fact.
  * @param declaration A declaration of the props to pass to the root component.


### PR DESCRIPTION
The function specificationFor returns a function. Change this to an object. Instead, support one function for mapping a specification to a component as props, and another to return the specification results from a React hook.